### PR TITLE
Add license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 Pink Programming
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # Pink Web Dev 2019
-This project contains resources and ideas for the Pink Web Dev course that will be held during autumn 2019. All contents are under the MIT license and thus freely shareable, reusable and distributable. The contents are collected by the content team volunteers.
+This project contains resources and ideas for the Pink Web Dev course that will be held during autumn 2019. 
+
+# License
+
+All content linked or referenced from Full Stack Open is licensed under [Creative Commons BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/)
+
+All Khan Academy content is available for free at [www.khanacademy.org](www.khanacademy.org)
+
+All other contents are under the MIT license and thus freely shareable, reusable and distributable. If so, the (c) Pink Programming must be provided, as the contents are collected by the content team volunteers.


### PR DESCRIPTION
Changes made: 

- adding LICENSE file using one of Githubs templates
- collect the further info in a License-section of the readme

Motivation: 

Adding this stuff is required for intended re-use of external educational content. 

Also, MIT license was chosen for our own content based on what makes sense for Pink Programming as an organization. 